### PR TITLE
Multi-instance support, graceful upgrade, and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,4 +134,8 @@ monkeytype.sqlite3
 api-responses/
 *.ignore.*
 .DS_Store
+.claude/
 __pycache__/
+
+# Home Assistant
+.activities_list.json

--- a/README.md
+++ b/README.md
@@ -68,4 +68,7 @@ data:
 
 -   Activities are stored in `.activities_list_<entry_id>.json` in your `<config>` folder, one file per list. If you're upgrading from an older version, the legacy `.activities_list.json` is automatically migrated and a `.activities_list.json.bak` backup is created.
 -   An entity is created for each activity. The state of the entity is the datetime of when the activity is next due. You can use this entity to build notifications or your own custom cards.
--   Three services are exposed: `activity_manager.add_activity`, `activity_manager.update_activity`, `activity_manager.remove_activity`. When multiple lists are configured, pass `entry_id` to target the correct list. The update service can be used to reset the timer.
+-   Three services are exposed, all requiring an `entry_id` to identify which list to target:
+    -   `activity_manager.add_activity` — add a new activity (`name`, `category`, `frequency`, optional `last_completed`, optional `icon`)
+    -   `activity_manager.update_activity` — update an existing activity by `entity_id`; pass `now: true` to reset the timer to the current time, or `last_completed` to set a specific datetime
+    -   `activity_manager.remove_activity` — remove an activity by `entity_id`

--- a/README.md
+++ b/README.md
@@ -69,6 +69,6 @@ data:
 -   Activities are stored in `.activities_list_<entry_id>.json` in your `<config>` folder, one file per list. If you're upgrading from an older version, the legacy `.activities_list.json` is automatically migrated and a `.activities_list.json.bak` backup is created.
 -   An entity is created for each activity. The state of the entity is the datetime of when the activity is next due. You can use this entity to build notifications or your own custom cards.
 -   Three services are exposed:
-    -   `activity_manager.add_activity` — add a new activity; requires `list` (the name of the activity list, e.g. `"Home"`), `name`, `category`, `frequency`; optional `last_completed` and `icon`
+    -   `activity_manager.add_activity` — add a new activity; requires `list` (the name of the activity list as configured, e.g. `"Home"`; if you migrated from a legacy installation this will be `"Activity Manager"`), `name`, `category`, `frequency`; optional `last_completed` and `icon`
     -   `activity_manager.update_activity` — update an existing activity by `entity_id`; pass `now: true` to reset the timer to now, or `last_completed` to set a specific datetime
     -   `activity_manager.remove_activity` — remove an activity by `entity_id`

--- a/README.md
+++ b/README.md
@@ -105,7 +105,21 @@ Remove an activity permanently.
 
 ## Notifications
 
-Because each activity is a sensor entity, you can build automations around them. The example below sends a mobile notification at sunrise listing all overdue workout activities:
+### Blueprint
+
+A ready-made automation blueprint is included. Import it with one click:
+
+[![Import blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fpathofleastresistor%2Factivity-manager%2Fblob%2Fmain%2Fblueprints%2Fautomation%2Factivity_manager_notify.yaml)
+
+Configure:
+- **Notification service** — e.g. `notify.mobile_app_your_phone`
+- **Category filter** — leave blank to notify for all categories
+- **Time** — when to check each day
+- **Title** — notification title
+
+### Custom automations
+
+Because each activity is a sensor entity, you can build your own automations. The example below sends a mobile notification at sunrise listing all overdue workout activities:
 
 ```yaml
 service: notify.mobile_android_phone

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ data:
 
 -   Activities are stored in `.activities_list_<entry_id>.json` in your `<config>` folder, one file per list. If you're upgrading from an older version, the legacy `.activities_list.json` is automatically migrated and a `.activities_list.json.bak` backup is created.
 -   An entity is created for each activity. The state of the entity is the datetime of when the activity is next due. You can use this entity to build notifications or your own custom cards.
--   Three services are exposed, all requiring an `entry_id` to identify which list to target:
-    -   `activity_manager.add_activity` — add a new activity (`name`, `category`, `frequency`, optional `last_completed`, optional `icon`)
-    -   `activity_manager.update_activity` — update an existing activity by `entity_id`; pass `now: true` to reset the timer to the current time, or `last_completed` to set a specific datetime
+-   Three services are exposed:
+    -   `activity_manager.add_activity` — add a new activity; requires `entry_id` (to select the list), `name`, `category`, `frequency`; optional `last_completed` and `icon`
+    -   `activity_manager.update_activity` — update an existing activity by `entity_id`; pass `now: true` to reset the timer to now, or `last_completed` to set a specific datetime
     -   `activity_manager.remove_activity` — remove an activity by `entity_id`

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Once installed, you can use the link below to add the integration from the UI.
 
 [![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=activity_manager)
 
-If you're using the [Activity Manager Card](https://github.com/pathofleastresistor/activity-manager-card), then you all you need to do is add the Activity Manager Card to your dashboard. When you're creating the card, you'll have to supply a `category` attribute to the card.
+You can add multiple activity lists by adding the integration more than once — each instance is independent with its own set of activities.
+
+If you're using the [Activity Manager Card](https://github.com/pathofleastresistor/activity-manager-card), add the card to your dashboard and use the built-in editor to select which activity list to display. You can optionally filter by category.
 
 ### Notifications
 
@@ -64,6 +66,6 @@ data:
 
 ### More information
 
--   Activities are stored in .activities_list.json in your `<config>` folder
--   An entity is created for each activity (e.g. `sensor.<category>_<activity>`). The state of the activity is the datetime of when the activity is due. You can use this entity to build notifications or your own custom cards.
--   Three services are exposed: `activity_manager.add_activity`, `activity_manager.update_activity`, `activity_manager.remove_activity`. The update activity can be used to reset the timer.
+-   Activities are stored in `.activities_list_<entry_id>.json` in your `<config>` folder, one file per list. If you're upgrading from an older version, the legacy `.activities_list.json` is automatically migrated and a `.activities_list.json.bak` backup is created.
+-   An entity is created for each activity. The state of the entity is the datetime of when the activity is next due. You can use this entity to build notifications or your own custom cards.
+-   Three services are exposed: `activity_manager.add_activity`, `activity_manager.update_activity`, `activity_manager.remove_activity`. When multiple lists are configured, pass `entry_id` to target the correct list. The update service can be used to reset the timer.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,6 @@ data:
 -   Activities are stored in `.activities_list_<entry_id>.json` in your `<config>` folder, one file per list. If you're upgrading from an older version, the legacy `.activities_list.json` is automatically migrated and a `.activities_list.json.bak` backup is created.
 -   An entity is created for each activity. The state of the entity is the datetime of when the activity is next due. You can use this entity to build notifications or your own custom cards.
 -   Three services are exposed:
-    -   `activity_manager.add_activity` — add a new activity; requires `entry_id` (to select the list), `name`, `category`, `frequency`; optional `last_completed` and `icon`
+    -   `activity_manager.add_activity` — add a new activity; requires `list` (the name of the activity list, e.g. `"Home"`), `name`, `category`, `frequency`; optional `last_completed` and `icon`
     -   `activity_manager.update_activity` — update an existing activity by `entity_id`; pass `now: true` to reset the timer to now, or `last_completed` to set a specific datetime
     -   `activity_manager.remove_activity` — remove an activity by `entity_id`

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # activity-manager
 
-Manager recurring tasks from within Home Assistant
+Track recurring activities from within Home Assistant.
 
 Use the companion [Activity Manager Card](https://github.com/pathofleastresistor/activity-manager-card) for the best experience.
 
-The core idea is that an activity happens on a recurring basis, which is stored in the `frequency` field when adding an activity. By default, the activity is last completed when you first add the activity and then the timer can be reset.
+Each activity has a frequency (e.g. every 7 days). The integration tracks when it was last completed and exposes a sensor whose state is the next due datetime. Activities can be overdue, due soon, or on track.
 
 <p align="center">
   <img width="600" src="images/activitymanager.gif">
@@ -12,35 +12,102 @@ The core idea is that an activity happens on a recurring basis, which is stored 
 
 ## Installation
 
-### Manually
-
-Clone or download this repository and copy the "activity_manager" directory to your "custom_components" directory in your config directory
-
-`<config directory>/custom_components/activity-manager/...`
-
 ### HACS
 
 1. Open the HACS section of Home Assistant.
 2. Click the "..." button in the top right corner and select "Custom Repositories."
-3. In the window that opens paste this Github URL.
-4. Select "Integration"
-5. In the window that opens when you select it click om "Install This Repository in HACS"
+3. Paste this repository's GitHub URL, select "Integration", and click Install.
 
-## Usage
+### Manually
 
-Once installed, you can use the link below to add the integration from the UI.
+Copy the `activity_manager` directory into your HA config directory:
+
+```
+<config>/custom_components/activity_manager/
+```
+
+## Setup
+
+Once installed, add the integration from the UI:
 
 [![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=activity_manager)
 
-You can add multiple activity lists by adding the integration more than once — each instance is independent with its own set of activities.
+You will be prompted to give the list a name (e.g. "Home", "Garden", "Car"). You can add the integration multiple times to create independent lists.
 
-If you're using the [Activity Manager Card](https://github.com/pathofleastresistor/activity-manager-card), add the card to your dashboard and use the built-in editor to select which activity list to display. You can optionally filter by category.
+### Upgrading from a legacy installation
 
-### Notifications
+If you have an existing installation (v1.2 or earlier), your data and config entry will be automatically migrated on first startup:
 
-Because entities are exposed for each activity, you can build custom notifications. The example below runs an automation at sunrise to remind the user if they are past due on workout activities:
+- Your config entry will be renamed to **"Activity Manager"** (the name used by all legacy installs).
+- Your activities will be migrated from `.activities_list.json` to a per-list file. A backup is saved as `.activities_list.json.bak` before migration.
 
-```
+No manual steps required.
+
+## Card
+
+Add the [Activity Manager Card](https://github.com/pathofleastresistor/activity-manager-card) to your dashboard. Use the built-in card editor to:
+
+- Select which activity list to display
+- Optionally filter by category
+- Add, edit, and remove activities directly from the card
+
+## Entities
+
+An entity is created for each activity under `sensor.<list>_<category>_<name>`. The entity state is the datetime when the activity is next due.
+
+Each entity exposes the following attributes:
+
+| Attribute | Description |
+|-----------|-------------|
+| `category` | The activity's category |
+| `last_completed` | ISO datetime of the last completion |
+| `frequency_ms` | Repeat interval in milliseconds |
+| `frequency` | Repeat interval as `{days, hours, minutes}` |
+| `id` | Internal activity ID |
+| `entry_id` | Config entry ID of the list this activity belongs to |
+| `list_title` | Human-readable name of the list |
+
+## Services
+
+### `activity_manager.add_activity`
+
+Add a new activity to a list.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `list` | Yes | Name of the activity list (e.g. `"Home"`; legacy installs use `"Activity Manager"`) |
+| `name` | Yes | Activity name |
+| `category` | Yes | Category (used for grouping and filtering) |
+| `frequency` | Yes | How often the activity repeats. Either an integer number of seconds, or an object with `days`, `hours`, and/or `minutes` |
+| `last_completed` | No | ISO datetime of last completion. Defaults to now. |
+| `icon` | No | MDI icon name (e.g. `mdi:car`) |
+
+### `activity_manager.update_activity`
+
+Update an existing activity.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `entity_id` | Yes | Entity ID of the activity to update |
+| `now` | No | Set to `true` to mark the activity as completed right now |
+| `last_completed` | No | ISO datetime to set as the last completion time |
+| `category` | No | New category |
+| `frequency` | No | New frequency (same format as `add_activity`) |
+| `icon` | No | New icon |
+
+### `activity_manager.remove_activity`
+
+Remove an activity permanently.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `entity_id` | Yes | Entity ID of the activity to remove |
+
+## Notifications
+
+Because each activity is a sensor entity, you can build automations around them. The example below sends a mobile notification at sunrise listing all overdue workout activities:
+
+```yaml
 service: notify.mobile_android_phone
 data:
   title: >-
@@ -64,11 +131,12 @@ data:
     notification_icon: "mdi:dumbbell"
 ```
 
-### More information
+## Storage
 
--   Activities are stored in `.activities_list_<entry_id>.json` in your `<config>` folder, one file per list. If you're upgrading from an older version, the legacy `.activities_list.json` is automatically migrated and a `.activities_list.json.bak` backup is created.
--   An entity is created for each activity. The state of the entity is the datetime of when the activity is next due. You can use this entity to build notifications or your own custom cards.
--   Three services are exposed:
-    -   `activity_manager.add_activity` — add a new activity; requires `list` (the name of the activity list as configured, e.g. `"Home"`; if you migrated from a legacy installation this will be `"Activity Manager"`), `name`, `category`, `frequency`; optional `last_completed` and `icon`
-    -   `activity_manager.update_activity` — update an existing activity by `entity_id`; pass `now: true` to reset the timer to now, or `last_completed` to set a specific datetime
-    -   `activity_manager.remove_activity` — remove an activity by `entity_id`
+Activities are stored in your HA config directory, one file per list:
+
+```
+<config>/.activities_list_<entry_id>.json
+```
+
+Legacy installs stored everything in `.activities_list.json`. This file is automatically migrated on first startup and a `.activities_list.json.bak` backup is kept.

--- a/blueprints/automation/activity_manager_notify.yaml
+++ b/blueprints/automation/activity_manager_notify.yaml
@@ -1,0 +1,68 @@
+blueprint:
+  name: Activity Manager — Overdue Notification
+  description: >
+    Send a notification when one or more activities are overdue.
+    Optionally filter by category and customize the notification target and schedule.
+  domain: automation
+  input:
+    notify_target:
+      name: Notification service
+      description: The notify service to call (e.g. notify.mobile_app_your_phone).
+      selector:
+        text: {}
+    category:
+      name: Category filter (optional)
+      description: Only notify for activities in this category. Leave blank to include all categories.
+      default: ""
+      selector:
+        text: {}
+    time:
+      name: Time to check
+      description: When to run the check each day.
+      default: "08:00:00"
+      selector:
+        time: {}
+    title:
+      name: Notification title
+      description: Title of the notification.
+      default: "Overdue activities"
+      selector:
+        text: {}
+
+trigger:
+  - platform: time
+    at: !input time
+
+variables:
+  category_filter: !input category
+
+condition:
+  - condition: template
+    value_template: >
+      {% set activities = states.sensor
+        | selectattr('attributes.integration', 'eq', 'activity_manager')
+        | selectattr('state', 'ne', 'unavailable')
+        | selectattr('state', 'ne', 'unknown')
+        | list %}
+      {% if category_filter != "" %}
+        {% set activities = activities | selectattr('attributes.category', 'eq', category_filter) | list %}
+      {% endif %}
+      {{ activities | selectattr('state', 'lt', now().isoformat()) | list | count > 0 }}
+
+action:
+  - service: !input notify_target
+    data:
+      title: !input title
+      message: >
+        {% set activities = states.sensor
+          | selectattr('attributes.integration', 'eq', 'activity_manager')
+          | selectattr('state', 'ne', 'unavailable')
+          | selectattr('state', 'ne', 'unknown')
+          | list %}
+        {% if category_filter != "" %}
+          {% set activities = activities | selectattr('attributes.category', 'eq', category_filter) | list %}
+        {% endif %}
+        {% set overdue = activities | selectattr('state', 'lt', now().isoformat()) | list %}
+        {% for a in overdue %}
+        - {{ a.name }} ({{ a.state | as_datetime | relative_time }} ago)
+        {% endfor %}

--- a/custom_components/activity_manager/__init__.py
+++ b/custom_components/activity_manager/__init__.py
@@ -1,139 +1,262 @@
+"""Activity Manager integration."""
 from __future__ import annotations
-from typing import Any
-from datetime import datetime, timedelta
+
 import logging
+from typing import Any
+
 import voluptuous as vol
-import uuid
-import json
-from homeassistant.helpers.json import save_json
+
 from homeassistant.components import websocket_api
-from homeassistant.helpers.entity_registry import async_get
-from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall, callback
-import homeassistant.helpers.config_validation as cv
-from homeassistant.util.json import JsonArrayType, load_json_array
-from homeassistant import config_entries
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.entity_registry import async_get as er_async_get
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.util import slugify
-from homeassistant.util import dt
-from .const import DOMAIN
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    DOMAIN,
+    PLATFORMS,
+    SERVICE_ADD,
+    SERVICE_REMOVE,
+    SERVICE_UPDATE,
+    WS_ADD,
+    WS_ITEMS,
+    WS_REMOVE,
+    WS_UPDATE,
+)
+from .coordinator import ActivityManagerCoordinator
 from .utils import dt_as_local
 
 _LOGGER = logging.getLogger(__name__)
 
-PERSISTENCE = ".activities_list.json"
+# ---------------------------------------------------------------------------
+# Service schemas — entry_id required to route to the right list
+# ---------------------------------------------------------------------------
+
+_FREQUENCY_SCHEMA = vol.Any(
+    vol.All(int, vol.Range(min=1)),
+    vol.Schema(
+        {
+            vol.Optional("days"): vol.Coerce(int),
+            vol.Optional("hours"): vol.Coerce(int),
+            vol.Optional("minutes"): vol.Coerce(int),
+            vol.Optional("seconds"): vol.Coerce(int),
+        }
+    ),
+)
+
+ADD_ACTIVITY_SCHEMA = vol.Schema(
+    {
+        vol.Required("entry_id"): cv.string,
+        vol.Required("name"): cv.string,
+        vol.Required("category"): cv.string,
+        vol.Required("frequency"): _FREQUENCY_SCHEMA,
+        vol.Optional("last_completed"): cv.string,
+        vol.Optional("icon"): cv.string,
+    }
+)
+
+REMOVE_ACTIVITY_SCHEMA = vol.Schema(
+    {
+        vol.Required("entry_id"): cv.string,
+        vol.Required("entity_id"): cv.entity_id,
+    }
+)
+
+UPDATE_ACTIVITY_SCHEMA = vol.Schema(
+    {
+        vol.Required("entry_id"): cv.string,
+        vol.Required("entity_id"): cv.entity_id,
+        vol.Optional("last_completed"): cv.string,
+        vol.Optional("now"): cv.boolean,
+        vol.Optional("category"): cv.string,
+        vol.Optional("frequency"): _FREQUENCY_SCHEMA,
+        vol.Optional("icon"): cv.string,
+    }
+)
+
+
+def _get_coordinator(hass: HomeAssistant, entry_id: str) -> ActivityManagerCoordinator | None:
+    """Look up a coordinator by entry_id."""
+    return hass.data.get(DOMAIN, {}).get(entry_id)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Initialize the activity."""
+    """Handle legacy YAML-based setup by triggering a config flow import."""
+    return True
 
-    if DOMAIN not in config:
-        return True
 
-    # hass.async_create_task(
-    #     discovery.async_load_platform(hass, "sensor", DOMAIN, None, hass_config=config)
-    # )
+async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Set up an Activity Manager list from a config entry."""
+    coordinator = ActivityManagerCoordinator(hass, config_entry)
+    await coordinator.async_load()
 
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_IMPORT}
-        )
-    )
+    hass.data.setdefault(DOMAIN, {})
+    # Register services and WS handlers exactly once, before adding this entry,
+    # using a separate flag key so the check is race-free even when HA loads
+    # multiple config entries concurrently.
+    first_entry = f"{DOMAIN}_registered" not in hass.data
+    if first_entry:
+        hass.data[f"{DOMAIN}_registered"] = True
+        _register_services(hass)
+        _register_websocket_handlers(hass)
+
+    hass.data[DOMAIN][config_entry.entry_id] = coordinator
+
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     return True
 
 
-async def async_setup_entry(
-    hass: HomeAssistant,
-    config_entry: ConfigEntry,
-) -> bool:
-    """Set up Activity Manager from a config entry."""
-    # Add sensor
-    await hass.config_entries.async_forward_entry_setups(config_entry, ["sensor"])
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
-    async def add_item_service(call: ServiceCall) -> None:
-        """Add an item with `name`."""
-        data = hass.data[DOMAIN]
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id, None)
 
-        name = call.data.get("name")
-        category = call.data.get("category")
-        frequency_str = call.data.get("frequency")
+        # Remove services and websocket handlers only when the last entry is gone.
+        if not hass.data[DOMAIN]:
+            hass.services.async_remove(DOMAIN, SERVICE_ADD)
+            hass.services.async_remove(DOMAIN, SERVICE_REMOVE)
+            hass.services.async_remove(DOMAIN, SERVICE_UPDATE)
+            hass.data.pop(f"{DOMAIN}_registered", None)
+
+    return unload_ok
+
+
+# ---------------------------------------------------------------------------
+# Services
+# ---------------------------------------------------------------------------
+
+def _register_services(hass: HomeAssistant) -> None:
+    """Register domain services (called once on first entry setup)."""
+
+    async def add_activity_service(call: ServiceCall) -> None:
+        coordinator = _get_coordinator(hass, call.data["entry_id"])
+        if not coordinator:
+            _LOGGER.error("add_activity: unknown entry_id %s", call.data["entry_id"])
+            return
+
         last_completed = call.data.get("last_completed")
-        icon = call.data.get("icon")
-
         if last_completed:
             last_completed = dt_as_local(last_completed)
-        else:
-            last_completed = dt.now().isoformat()
 
-        await data.async_add_activity(
-            name, category, frequency_str, icon=icon, last_completed=last_completed
+        await coordinator.async_add_activity(
+            name=call.data["name"],
+            category=call.data["category"],
+            frequency=call.data["frequency"],
+            icon=call.data.get("icon"),
+            last_completed=last_completed,
         )
 
-    async def remove_item_service(call: ServiceCall) -> None:
-        data = hass.data[DOMAIN]
+    async def remove_activity_service(call: ServiceCall) -> None:
+        coordinator = _get_coordinator(hass, call.data["entry_id"])
+        if not coordinator:
+            _LOGGER.error("remove_activity: unknown entry_id %s", call.data["entry_id"])
+            return
 
-        entity_id = call.data.get("entity_id")
+        entity_registry = er_async_get(hass)
+        entity = entity_registry.entities.get(call.data["entity_id"])
+        if entity:
+            # Strip the entry_id prefix to get the raw activity id.
+            activity_id = entity.unique_id.removeprefix(f"{coordinator.entry_id}_")
+            await coordinator.async_remove_activity(activity_id)
+        else:
+            _LOGGER.warning("remove_activity: entity not found: %s", call.data["entity_id"])
 
-        if entity_id:
-            entity_registry = async_get(hass)
-            entity = entity_registry.entities.get(entity_id)
-            if entity:
-                await data.async_remove_activity(entity.unique_id)
+    async def update_activity_service(call: ServiceCall) -> None:
+        coordinator = _get_coordinator(hass, call.data["entry_id"])
+        if not coordinator:
+            _LOGGER.error("update_activity: unknown entry_id %s", call.data["entry_id"])
+            return
 
-    async def update_item_service(call: ServiceCall) -> None:
-        data = hass.data[DOMAIN]
-        entity_id = call.data.get("entity_id")
+        entity_registry = er_async_get(hass)
+        entity = entity_registry.entities.get(call.data["entity_id"])
+        if not entity:
+            _LOGGER.warning("update_activity: entity not found: %s", call.data["entity_id"])
+            return
+
         last_completed = call.data.get("last_completed")
-        category = call.data.get("category")
-        now = call.data.get("now")
-        frequency = call.data.get("frequency")
-        icon = call.data.get("icon")
-
-        if last_completed:
+        if call.data.get("now"):
+            last_completed = dt_util.now().isoformat()
+        elif last_completed:
             last_completed = dt_as_local(last_completed)
 
-        if now:
-            last_completed = dt.now().isoformat()
+        activity_id = entity.unique_id.removeprefix(f"{coordinator.entry_id}_")
+        await coordinator.async_update_activity(
+            activity_id,
+            last_completed=last_completed,
+            category=call.data.get("category"),
+            frequency=call.data.get("frequency"),
+            icon=call.data.get("icon"),
+        )
 
-        if entity_id:
-            entity_registry = async_get(hass)
-            entity = entity_registry.entities.get(entity_id)
-            if entity:
-                await data.async_update_activity(
-                    entity.unique_id,
-                    last_completed=last_completed,
-                    category=category,
-                    frequency=frequency,
-                    icon=icon,
-                )
+    hass.services.async_register(DOMAIN, SERVICE_ADD, add_activity_service, schema=ADD_ACTIVITY_SCHEMA)
+    hass.services.async_register(DOMAIN, SERVICE_REMOVE, remove_activity_service, schema=REMOVE_ACTIVITY_SCHEMA)
+    hass.services.async_register(DOMAIN, SERVICE_UPDATE, update_activity_service, schema=UPDATE_ACTIVITY_SCHEMA)
 
-    hass.services.async_register(DOMAIN, "add_activity", add_item_service)
-    hass.services.async_register(DOMAIN, "remove_activity", remove_item_service)
-    hass.services.async_register(DOMAIN, "update_activity", update_item_service)
+
+# ---------------------------------------------------------------------------
+# Websocket handlers
+# ---------------------------------------------------------------------------
+
+def _register_websocket_handlers(hass: HomeAssistant) -> None:
+    """Register websocket commands (called once on first entry setup)."""
 
     @callback
     @websocket_api.websocket_command(
-        {vol.Required("type"): "activity_manager/items", vol.Optional("category"): str}
+        {
+            vol.Required("type"): WS_ITEMS,
+            vol.Optional("entry_id"): str,
+            vol.Optional("category"): str,
+        }
     )
     def websocket_handle_items(
         hass: HomeAssistant,
         connection: websocket_api.ActiveConnection,
         msg: dict[str, Any],
     ) -> None:
-        """Handle getting activity_manager items."""
-        connection.send_message(
-            websocket_api.result_message(msg["id"], hass.data[DOMAIN].items)
-        )
+        """Return activity items. Optionally filter by entry_id and/or category."""
+        entry_id = msg.get("entry_id")
+        category = msg.get("category")
+
+        if entry_id:
+            coordinator = _get_coordinator(hass, entry_id)
+            if coordinator is None:
+                connection.send_error(msg["id"], "not_found", f"No list with entry_id {entry_id!r}")
+                return
+            items = list(coordinator.data or [])
+            # Tag each item with list metadata for the card.
+            for item in items:
+                item = dict(item)
+            items = [
+                {**i, "entry_id": coordinator.entry_id, "list_title": coordinator.title}
+                for i in items
+            ]
+        else:
+            # No entry_id — return all lists merged.
+            items = []
+            for coord in hass.data.get(DOMAIN, {}).values():
+                items.extend(
+                    {**i, "entry_id": coord.entry_id, "list_title": coord.title}
+                    for i in (coord.data or [])
+                )
+
+        if category:
+            items = [i for i in items if i.get("category") == category]
+
+        connection.send_message(websocket_api.result_message(msg["id"], items))
 
     @websocket_api.websocket_command(
         {
-            vol.Required("type"): "activity_manager/add",
+            vol.Required("type"): WS_ADD,
+            vol.Required("entry_id"): str,
             vol.Required("name"): str,
             vol.Required("category"): str,
             vol.Required("frequency"): dict,
-            vol.Optional("last_completed"): int,
+            vol.Optional("last_completed"): str,
             vol.Optional("icon"): str,
         }
     )
@@ -143,36 +266,42 @@ async def async_setup_entry(
         connection: websocket_api.ActiveConnection,
         msg: dict[str, Any],
     ) -> None:
-        """Handle updating activity."""
-        id = msg.pop("id")
-        name = msg.pop("name")
-        category = msg.pop("category")
-        frequency = msg.pop("frequency")
-        icon = msg.get("icon")
-        last_completed = msg.get("last_completed")
-        msg.pop("type")
+        """Handle adding an activity via websocket."""
+        msg_id = msg["id"]
+        coordinator = _get_coordinator(hass, msg["entry_id"])
+        if coordinator is None:
+            connection.send_error(msg_id, "not_found", f"No list with entry_id {msg['entry_id']!r}")
+            return
 
-        if last_completed:
-            last_completed = dt_as_local(last_completed)
-        else:
-            last_completed = dt.now().isoformat()
+        last_completed_raw = msg.get("last_completed")
+        last_completed = dt_as_local(str(last_completed_raw)) if last_completed_raw else None
 
-        item = await hass.data[DOMAIN].async_add_activity(
-            name,
-            category,
-            frequency,
-            last_completed=last_completed,
-            context=connection.context(msg),
-        )
-        connection.send_message(websocket_api.result_message(id, item))
+        try:
+            item = await coordinator.async_add_activity(
+                name=msg["name"],
+                category=msg["category"],
+                frequency=msg["frequency"],
+                icon=msg.get("icon"),
+                last_completed=last_completed,
+                context=connection.context(msg),
+            )
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.exception("Error adding activity")
+            connection.send_error(msg_id, "add_failed", str(err))
+            return
+
+        connection.send_message(websocket_api.result_message(msg_id, item))
 
     @websocket_api.websocket_command(
         {
-            vol.Required("type"): "activity_manager/update",
+            vol.Required("type"): WS_UPDATE,
+            vol.Required("entry_id"): str,
             vol.Required("item_id"): str,
             vol.Optional("last_completed"): str,
             vol.Optional("name"): str,
             vol.Optional("category"): str,
+            vol.Optional("frequency"): dict,
+            vol.Optional("icon"): str,
         }
     )
     @websocket_api.async_response
@@ -181,26 +310,44 @@ async def async_setup_entry(
         connection: websocket_api.ActiveConnection,
         msg: dict[str, Any],
     ) -> None:
-        """Handle updating activity."""
-        msg_id = msg.pop("id")
-        item_id = msg.pop("item_id")
-        msg.pop("type")
+        """Handle updating an activity via websocket."""
+        msg_id = msg["id"]
+        coordinator = _get_coordinator(hass, msg["entry_id"])
+        if coordinator is None:
+            connection.send_error(msg_id, "not_found", f"No list with entry_id {msg['entry_id']!r}")
+            return
+
         last_completed = msg.get("last_completed")
-        data = msg
-
         if last_completed:
-            last_completed = dt.as_local(dt.parse_datetime(last_completed)).isoformat()
+            parsed = dt_util.parse_datetime(last_completed)
+            last_completed = dt_util.as_local(parsed).isoformat() if parsed else dt_util.now().isoformat()
         else:
-            last_completed = dt.now().isoformat()
+            last_completed = dt_util.now().isoformat()
 
-        item = await hass.data[DOMAIN].async_update_activity(
-            item_id, last_completed=last_completed, context=connection.context(msg)
-        )
+        try:
+            item = await coordinator.async_update_activity(
+                item_id=msg["item_id"],
+                last_completed=last_completed,
+                category=msg.get("category"),
+                frequency=msg.get("frequency"),
+                icon=msg.get("icon"),
+                context=connection.context(msg),
+            )
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.exception("Error updating activity")
+            connection.send_error(msg_id, "update_failed", str(err))
+            return
+
+        if item is None:
+            connection.send_error(msg_id, "not_found", f"Activity {msg['item_id']} not found")
+            return
+
         connection.send_message(websocket_api.result_message(msg_id, item))
 
     @websocket_api.websocket_command(
         {
-            vol.Required("type"): "activity_manager/remove",
+            vol.Required("type"): WS_REMOVE,
+            vol.Required("entry_id"): str,
             vol.Required("item_id"): str,
         }
     )
@@ -210,25 +357,33 @@ async def async_setup_entry(
         connection: websocket_api.ActiveConnection,
         msg: dict[str, Any],
     ) -> None:
-        """Handle removing activity."""
-        msg_id = msg.pop("id")
-        item_id = msg.pop("item_id")
-        msg.pop("type")
-        data = msg
+        """Handle removing an activity via websocket."""
+        msg_id = msg["id"]
+        coordinator = _get_coordinator(hass, msg["entry_id"])
+        if coordinator is None:
+            connection.send_error(msg_id, "not_found", f"No list with entry_id {msg['entry_id']!r}")
+            return
 
-        item = await hass.data[DOMAIN].async_remove_activity(
-            item_id, connection.context(msg)
-        )
+        try:
+            item = await coordinator.async_remove_activity(
+                item_id=msg["item_id"],
+                context=connection.context(msg),
+            )
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.exception("Error removing activity")
+            connection.send_error(msg_id, "remove_failed", str(err))
+            return
+
+        if item is None:
+            connection.send_error(msg_id, "not_found", f"Activity {msg['item_id']} not found")
+            return
+
         connection.send_message(websocket_api.result_message(msg_id, item))
 
-    websocket_api.async_register_command(hass, websocket_handle_items)
-    websocket_api.async_register_command(hass, websocket_handle_add)
-    websocket_api.async_register_command(hass, websocket_handle_update)
-    websocket_api.async_register_command(hass, websocket_handle_remove)
-
-    return True
-
-
-async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload the config entry when it changed."""
-    await hass.config_entries.async_reload(entry.entry_id)
+    ws_unsubs = [
+        websocket_api.async_register_command(hass, websocket_handle_items),
+        websocket_api.async_register_command(hass, websocket_handle_add),
+        websocket_api.async_register_command(hass, websocket_handle_update),
+        websocket_api.async_register_command(hass, websocket_handle_remove),
+    ]
+    hass.data[f"{DOMAIN}_ws_unsubs"] = ws_unsubs

--- a/custom_components/activity_manager/__init__.py
+++ b/custom_components/activity_manager/__init__.py
@@ -328,6 +328,7 @@ def _register_websocket_handlers(hass: HomeAssistant) -> None:
             item = await coordinator.async_update_activity(
                 item_id=msg["item_id"],
                 last_completed=last_completed,
+                name=msg.get("name"),
                 category=msg.get("category"),
                 frequency=msg.get("frequency"),
                 icon=msg.get("icon"),

--- a/custom_components/activity_manager/__init__.py
+++ b/custom_components/activity_manager/__init__.py
@@ -59,14 +59,12 @@ ADD_ACTIVITY_SCHEMA = vol.Schema(
 
 REMOVE_ACTIVITY_SCHEMA = vol.Schema(
     {
-        vol.Required("entry_id"): cv.string,
         vol.Required("entity_id"): cv.entity_id,
     }
 )
 
 UPDATE_ACTIVITY_SCHEMA = vol.Schema(
     {
-        vol.Required("entry_id"): cv.string,
         vol.Required("entity_id"): cv.entity_id,
         vol.Optional("last_completed"): cv.string,
         vol.Optional("now"): cv.boolean,
@@ -152,30 +150,33 @@ def _register_services(hass: HomeAssistant) -> None:
         )
 
     async def remove_activity_service(call: ServiceCall) -> None:
-        coordinator = _get_coordinator(hass, call.data["entry_id"])
-        if not coordinator:
-            _LOGGER.error("remove_activity: unknown entry_id %s", call.data["entry_id"])
-            return
-
         entity_registry = er_async_get(hass)
         entity = entity_registry.entities.get(call.data["entity_id"])
-        if entity:
-            # Strip the entry_id prefix to get the raw activity id.
-            activity_id = entity.unique_id.removeprefix(f"{coordinator.entry_id}_")
-            await coordinator.async_remove_activity(activity_id)
-        else:
+        if not entity:
             _LOGGER.warning("remove_activity: entity not found: %s", call.data["entity_id"])
-
-    async def update_activity_service(call: ServiceCall) -> None:
-        coordinator = _get_coordinator(hass, call.data["entry_id"])
-        if not coordinator:
-            _LOGGER.error("update_activity: unknown entry_id %s", call.data["entry_id"])
             return
 
+        # Derive entry_id from the entity's unique_id prefix (<entry_id>_<activity_id>).
+        entry_id, _, activity_id = entity.unique_id.partition("_")
+        coordinator = _get_coordinator(hass, entry_id)
+        if not coordinator:
+            _LOGGER.error("remove_activity: no coordinator for entry_id %s", entry_id)
+            return
+
+        await coordinator.async_remove_activity(activity_id)
+
+    async def update_activity_service(call: ServiceCall) -> None:
         entity_registry = er_async_get(hass)
         entity = entity_registry.entities.get(call.data["entity_id"])
         if not entity:
             _LOGGER.warning("update_activity: entity not found: %s", call.data["entity_id"])
+            return
+
+        # Derive entry_id from the entity's unique_id prefix (<entry_id>_<activity_id>).
+        entry_id, _, activity_id = entity.unique_id.partition("_")
+        coordinator = _get_coordinator(hass, entry_id)
+        if not coordinator:
+            _LOGGER.error("update_activity: no coordinator for entry_id %s", entry_id)
             return
 
         last_completed = call.data.get("last_completed")
@@ -184,7 +185,6 @@ def _register_services(hass: HomeAssistant) -> None:
         elif last_completed:
             last_completed = dt_as_local(last_completed)
 
-        activity_id = entity.unique_id.removeprefix(f"{coordinator.entry_id}_")
         await coordinator.async_update_activity(
             activity_id,
             last_completed=last_completed,

--- a/custom_components/activity_manager/__init__.py
+++ b/custom_components/activity_manager/__init__.py
@@ -48,7 +48,7 @@ _FREQUENCY_SCHEMA = vol.Any(
 
 ADD_ACTIVITY_SCHEMA = vol.Schema(
     {
-        vol.Required("entry_id"): cv.string,
+        vol.Required("list"): cv.string,
         vol.Required("name"): cv.string,
         vol.Required("category"): cv.string,
         vol.Required("frequency"): _FREQUENCY_SCHEMA,
@@ -78,6 +78,14 @@ UPDATE_ACTIVITY_SCHEMA = vol.Schema(
 def _get_coordinator(hass: HomeAssistant, entry_id: str) -> ActivityManagerCoordinator | None:
     """Look up a coordinator by entry_id."""
     return hass.data.get(DOMAIN, {}).get(entry_id)
+
+
+def _get_coordinator_by_title(hass: HomeAssistant, title: str) -> ActivityManagerCoordinator | None:
+    """Look up a coordinator by list title (case-insensitive)."""
+    for coord in hass.data.get(DOMAIN, {}).values():
+        if coord.title.lower() == title.lower():
+            return coord
+    return None
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -132,9 +140,9 @@ def _register_services(hass: HomeAssistant) -> None:
     """Register domain services (called once on first entry setup)."""
 
     async def add_activity_service(call: ServiceCall) -> None:
-        coordinator = _get_coordinator(hass, call.data["entry_id"])
+        coordinator = _get_coordinator_by_title(hass, call.data["list"])
         if not coordinator:
-            _LOGGER.error("add_activity: unknown entry_id %s", call.data["entry_id"])
+            _LOGGER.error("add_activity: no list named %r", call.data["list"])
             return
 
         last_completed = call.data.get("last_completed")

--- a/custom_components/activity_manager/config_flow.py
+++ b/custom_components/activity_manager/config_flow.py
@@ -1,48 +1,77 @@
-"""Config flow for ActivityManager."""
+"""Config flow for Activity Manager."""
+from __future__ import annotations
+
+import logging
+
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.data_entry_flow import FlowResult
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.util import slugify
 
-from .const import DOMAIN  # import the domain from const.py
-import logging
+from .const import DOMAIN, ENTRY_MINOR_VERSION, ENTRY_VERSION
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class ActivityManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a ActivityManager config flow."""
+async def async_migrate_entry(hass: HomeAssistant, entry: config_entries.ConfigEntry) -> bool:
+    """Migrate a config entry to the current version."""
+    _LOGGER.debug(
+        "Migrating activity_manager config entry from version %s.%s",
+        entry.version,
+        entry.minor_version,
+    )
 
-    VERSION = 1
+    if entry.version == 1 and entry.minor_version < 3:
+        # v1.1/v1.2 → v1.3: set a proper unique_id and title from existing name.
+        name = entry.data.get("name", "Activity Manager")
+        hass.config_entries.async_update_entry(
+            entry,
+            title=name,
+            unique_id=slugify(name),
+            minor_version=3,
+        )
+
+    return True
+
+
+class ActivityManagerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle an Activity Manager config flow."""
+
+    VERSION = ENTRY_VERSION
+    MINOR_VERSION = ENTRY_MINOR_VERSION
 
     async def async_step_user(self, user_input=None):
-        """Handle the initial step."""
+        """Handle the initial step — ask for a list name."""
+        errors: dict[str, str] = {}
 
-        # Check if already configured
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-        
-        await self.async_set_unique_id(DOMAIN)
-        self._abort_if_unique_id_configured()
+        if user_input is not None:
+            name = user_input["name"].strip()
+            if not name:
+                errors["name"] = "name_required"
+            else:
+                await self.async_set_unique_id(slugify(name))
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(title=name, data={"name": name})
 
-        return self.async_create_entry(title="Activity Manager", data={'name': "Activity Manager"})
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema({vol.Required("name"): str}),
+            errors=errors,
+        )
 
-    async_step_import = async_step_user
-    
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry):
-        """Get the options flow for this handler."""
-        return ActivityManagerOptionsFlowHandler(config_entry)
+    def async_get_options_flow(config_entry: config_entries.ConfigEntry) -> ActivityManagerOptionsFlowHandler:
+        """Get the options flow handler."""
+        return ActivityManagerOptionsFlowHandler()
 
 
 class ActivityManagerOptionsFlowHandler(config_entries.OptionsFlow):
-    """Handle options for the Activity Manager component."""
-
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        """Initialize ActivityManager options flow."""
-        self.config_entry = config_entry
+    """Handle options for Activity Manager."""
 
     async def async_step_init(self, user_input=None):
-        """Manage the options."""
-        return self.async_abort(reason="single_instance_allowed")
+        """Show an empty options form (no configurable options yet)."""
+        if user_input is not None:
+            return self.async_create_entry(data={})
+
+        return self.async_show_form(step_id="init", data_schema=None)

--- a/custom_components/activity_manager/config_flow.py
+++ b/custom_components/activity_manager/config_flow.py
@@ -70,8 +70,18 @@ class ActivityManagerOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options for Activity Manager."""
 
     async def async_step_init(self, user_input=None):
-        """Show an empty options form (no configurable options yet)."""
+        """Allow renaming the activity list."""
         if user_input is not None:
+            name = user_input["name"].strip()
+            if name and name != self.config_entry.title:
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry, title=name
+                )
             return self.async_create_entry(data={})
 
-        return self.async_show_form(step_id="init", data_schema=None)
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {vol.Required("name", default=self.config_entry.title): str}
+            ),
+        )

--- a/custom_components/activity_manager/const.py
+++ b/custom_components/activity_manager/const.py
@@ -1,1 +1,36 @@
+"""Constants for the Activity Manager integration."""
+
 DOMAIN = "activity_manager"
+PERSISTENCE = ".activities_list.json"
+
+# Config entry versioning
+ENTRY_VERSION = 1
+ENTRY_MINOR_VERSION = 3
+
+# Platforms
+PLATFORMS = ["sensor"]
+
+# Websocket command types
+WS_ITEMS = "activity_manager/items"
+WS_ADD = "activity_manager/add"
+WS_UPDATE = "activity_manager/update"
+WS_REMOVE = "activity_manager/remove"
+
+# Bus event
+EVENT_UPDATED = "activity_manager_updated"
+
+# Service names
+SERVICE_ADD = "add_activity"
+SERVICE_REMOVE = "remove_activity"
+SERVICE_UPDATE = "update_activity"
+
+# Activity field names
+ATTR_ID = "id"
+ATTR_NAME = "name"
+ATTR_CATEGORY = "category"
+ATTR_FREQUENCY = "frequency"
+ATTR_FREQUENCY_MS = "frequency_ms"
+ATTR_LAST_COMPLETED = "last_completed"
+ATTR_ICON = "icon"
+
+DEFAULT_ICON = "mdi:checkbox-outline"

--- a/custom_components/activity_manager/coordinator.py
+++ b/custom_components/activity_manager/coordinator.py
@@ -74,6 +74,11 @@ class ActivityManagerCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         if os.path.exists(per_entry_path):
             raw = load_json_array(per_entry_path)
         elif os.path.exists(legacy_path):
+            backup_path = legacy_path + ".bak"
+            if not os.path.exists(backup_path):
+                import shutil
+                shutil.copy2(legacy_path, backup_path)
+                _LOGGER.info("Backed up legacy file to %s", backup_path)
             _LOGGER.info(
                 "Migrating activities from legacy file %s to %s",
                 legacy_path,

--- a/custom_components/activity_manager/coordinator.py
+++ b/custom_components/activity_manager/coordinator.py
@@ -197,6 +197,7 @@ class ActivityManagerCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         self,
         item_id: str,
         last_completed: str | None = None,
+        name: str | None = None,
         category: str | None = None,
         frequency: dict[str, int] | None = None,
         icon: str | None = None,
@@ -214,6 +215,8 @@ class ActivityManagerCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
 
         if last_completed is not None:
             item[ATTR_LAST_COMPLETED] = last_completed
+        if name is not None:
+            item[ATTR_NAME] = name
         if category is not None:
             item[ATTR_CATEGORY] = category
         if frequency is not None:

--- a/custom_components/activity_manager/coordinator.py
+++ b/custom_components/activity_manager/coordinator.py
@@ -1,0 +1,235 @@
+"""DataUpdateCoordinator for Activity Manager."""
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.helpers.json import save_json
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util import dt as dt_util
+from homeassistant.util.json import load_json_array
+
+from .const import (
+    ATTR_CATEGORY,
+    ATTR_FREQUENCY,
+    ATTR_FREQUENCY_MS,
+    ATTR_ICON,
+    ATTR_ID,
+    ATTR_LAST_COMPLETED,
+    ATTR_NAME,
+    DEFAULT_ICON,
+    DOMAIN,
+    EVENT_UPDATED,
+    PERSISTENCE,
+)
+from .utils import duration_to_ms
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ActivityManagerCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
+    """Coordinator that owns all activity data and persistence.
+
+    No update_interval — data is file-based. All updates are push-only via
+    async_set_updated_data(), which automatically notifies all CoordinatorEntity
+    subscribers.
+    """
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN}_{entry.entry_id}",
+        )
+        self._entry = entry
+        self.entry_id: str = entry.entry_id
+        self.title: str = entry.title
+
+        # Per-entry persistence file. Falls back to legacy file on first load
+        # so existing data migrates automatically.
+        self._persistence = f".activities_list_{entry.entry_id}.json"
+        self._legacy_persistence = PERSISTENCE
+
+        # Set by sensor.async_setup_entry so we can add new entities dynamically.
+        self.async_add_entities: AddEntitiesCallback | None = None
+
+    async def async_load(self) -> None:
+        """Load activities from disk and push to all listeners."""
+        items = await self.hass.async_add_executor_job(self._load_sync)
+        self.async_set_updated_data(items)
+
+    def _load_sync(self) -> list[dict[str, Any]]:
+        """Load and migrate items from disk. Runs in executor."""
+        per_entry_path = self.hass.config.path(self._persistence)
+        legacy_path = self.hass.config.path(self._legacy_persistence)
+
+        if os.path.exists(per_entry_path):
+            raw = load_json_array(per_entry_path)
+        elif os.path.exists(legacy_path):
+            _LOGGER.info(
+                "Migrating activities from legacy file %s to %s",
+                legacy_path,
+                per_entry_path,
+            )
+            raw = load_json_array(legacy_path)
+        else:
+            raw = []
+
+        result = []
+        for item in raw:
+            migrated = self._migrate_item(item)
+            if migrated is not None:
+                result.append(migrated)
+        return result
+
+    def _migrate_item(self, item: dict[str, Any]) -> dict[str, Any] | None:
+        """Normalise a raw dict from disk. Returns None to skip corrupt records."""
+        if ATTR_FREQUENCY not in item:
+            _LOGGER.warning(
+                "Skipping activity with no frequency field: %s", item.get(ATTR_ID)
+            )
+            return None
+        item[ATTR_FREQUENCY_MS] = duration_to_ms(item[ATTR_FREQUENCY])
+        item.setdefault(ATTR_ICON, DEFAULT_ICON)
+        return item
+
+    async def async_save(self) -> None:
+        """Persist current data to disk."""
+        await self.hass.async_add_executor_job(self._save_sync)
+
+    def _save_sync(self) -> None:
+        """Write items to per-entry file. Runs in executor."""
+        save_json(self.hass.config.path(self._persistence), self.data or [])
+
+    # ------------------------------------------------------------------
+    # Mutation methods — each operates on a copy so listeners always see
+    # a consistent snapshot.
+    # ------------------------------------------------------------------
+
+    async def async_add_activity(
+        self,
+        name: str,
+        category: str,
+        frequency: dict[str, int] | int,
+        icon: str = DEFAULT_ICON,
+        last_completed: str | None = None,
+        context: Context | None = None,
+    ) -> dict[str, Any]:
+        """Add a new activity, persist, and notify listeners."""
+        if last_completed is None:
+            last_completed = dt_util.now().isoformat()
+
+        item: dict[str, Any] = {
+            ATTR_ID: uuid.uuid4().hex,
+            ATTR_NAME: name,
+            ATTR_CATEGORY: category,
+            ATTR_FREQUENCY: frequency,
+            ATTR_FREQUENCY_MS: duration_to_ms(frequency),
+            ATTR_LAST_COMPLETED: last_completed,
+            ATTR_ICON: icon,
+        }
+
+        new_data = list(self.data or []) + [item]
+        self.async_set_updated_data(new_data)
+
+        # Add a new entity for this activity if the platform is already set up.
+        if self.async_add_entities is not None:
+            from .sensor import ActivityEntity  # avoid circular import at module level
+
+            self.async_add_entities([ActivityEntity(self, item[ATTR_ID])])
+
+        await self.async_save()
+
+        _LOGGER.debug("Added activity: %s", item)
+        self.hass.bus.async_fire(
+            EVENT_UPDATED,
+            {"action": "add", "item": item, "entry_id": self.entry_id},
+            context=context,
+        )
+        return item
+
+    async def async_remove_activity(
+        self,
+        item_id: str,
+        context: Context | None = None,
+    ) -> dict[str, Any] | None:
+        """Remove an activity by id, persist, and notify listeners."""
+        current = list(self.data or [])
+        item = next((i for i in current if i[ATTR_ID] == item_id), None)
+        if item is None:
+            _LOGGER.warning("Tried to remove unknown activity id: %s", item_id)
+            return None
+
+        new_data = [i for i in current if i[ATTR_ID] != item_id]
+        self.async_set_updated_data(new_data)
+
+        # Remove from entity registry so the sensor disappears from HA.
+        from homeassistant.helpers.entity_registry import async_get as er_async_get
+
+        entity_registry = er_async_get(self.hass)
+        unique_id = f"{self.entry_id}_{item_id}"
+        entity_entry = next(
+            (e for e in entity_registry.entities.values() if e.unique_id == unique_id),
+            None,
+        )
+        if entity_entry is not None:
+            entity_registry.async_remove(entity_entry.entity_id)
+
+        await self.async_save()
+
+        _LOGGER.debug("Removed activity: %s", item)
+        self.hass.bus.async_fire(
+            EVENT_UPDATED,
+            {"action": "remove", "item": item, "entry_id": self.entry_id},
+            context=context,
+        )
+        return item
+
+    async def async_update_activity(
+        self,
+        item_id: str,
+        last_completed: str | None = None,
+        category: str | None = None,
+        frequency: dict[str, int] | None = None,
+        icon: str | None = None,
+        context: Context | None = None,
+    ) -> dict[str, Any] | None:
+        """Update fields on an existing activity, persist, and notify listeners."""
+        current = list(self.data or [])
+        idx = next((i for i, it in enumerate(current) if it[ATTR_ID] == item_id), None)
+        if idx is None:
+            _LOGGER.warning("Tried to update unknown activity id: %s", item_id)
+            return None
+
+        # Work on a shallow copy of the item dict so the old snapshot is untouched.
+        item = dict(current[idx])
+
+        if last_completed is not None:
+            item[ATTR_LAST_COMPLETED] = last_completed
+        if category is not None:
+            item[ATTR_CATEGORY] = category
+        if frequency is not None:
+            item[ATTR_FREQUENCY] = frequency
+            item[ATTR_FREQUENCY_MS] = duration_to_ms(frequency)
+        if icon is not None:
+            item[ATTR_ICON] = icon
+
+        new_data = current[:idx] + [item] + current[idx + 1 :]
+        self.async_set_updated_data(new_data)
+        await self.async_save()
+
+        _LOGGER.debug("Updated activity: %s", item)
+        self.hass.bus.async_fire(
+            EVENT_UPDATED,
+            {"action": "updated", "item": item, "entry_id": self.entry_id},
+            context=context,
+        )
+        return item

--- a/custom_components/activity_manager/diagnostics.py
+++ b/custom_components/activity_manager/diagnostics.py
@@ -1,0 +1,47 @@
+"""Diagnostics support for Activity Manager."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    ATTR_CATEGORY,
+    ATTR_FREQUENCY,
+    ATTR_FREQUENCY_MS,
+    ATTR_ID,
+    ATTR_NAME,
+    DOMAIN,
+)
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+) -> dict[str, Any]:
+    """Return diagnostics for an Activity Manager config entry."""
+    coordinator = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    if coordinator is None:
+        return {"error": "coordinator not found"}
+
+    return {
+        "entry": {
+            "entry_id": entry.entry_id,
+            "title": entry.title,
+            "version": entry.version,
+            "minor_version": entry.minor_version,
+        },
+        "activity_count": len(coordinator.data or []),
+        "activities": [
+            {
+                ATTR_ID: item.get(ATTR_ID),
+                ATTR_NAME: item.get(ATTR_NAME),
+                ATTR_CATEGORY: item.get(ATTR_CATEGORY),
+                ATTR_FREQUENCY: item.get(ATTR_FREQUENCY),
+                ATTR_FREQUENCY_MS: item.get(ATTR_FREQUENCY_MS),
+                # last_completed intentionally omitted — reveals user behaviour (PII)
+            }
+            for item in (coordinator.data or [])
+        ],
+    }

--- a/custom_components/activity_manager/icons.json
+++ b/custom_components/activity_manager/icons.json
@@ -1,0 +1,5 @@
+{
+  "integration": {
+    "icon": "mdi:format-list-checkbox"
+  }
+}

--- a/custom_components/activity_manager/manifest.json
+++ b/custom_components/activity_manager/manifest.json
@@ -1,12 +1,15 @@
 {
-    "domain": "activity_manager",
-    "name": "Activity Manager",
-    "documentation": "https://github.com/pathofleastresistor/activity-manager/",
-    "config_flow": true,
-    "dependencies": [],
-    "codeowners": [],
-    "version": "0.0.6",
-    "description": "Manage recurring tasks from within Home Assistant",
-    "requirements": [],
-    "iot_class": "assumed_state"
-  }
+  "domain": "activity_manager",
+  "name": "Activity Manager",
+  "documentation": "https://github.com/pathofleastresistor/activity-manager/",
+  "config_flow": true,
+  "integration_type": "service",
+  "dependencies": [],
+  "codeowners": [],
+  "version": "0.2.0",
+  "description": "Manage recurring tasks from within Home Assistant",
+  "requirements": [],
+  "iot_class": "local_push",
+  "loggers": ["custom_components.activity_manager"],
+  "quality_scale": "custom"
+}

--- a/custom_components/activity_manager/sensor.py
+++ b/custom_components/activity_manager/sensor.py
@@ -1,279 +1,127 @@
+"""Sensor platform for Activity Manager."""
 from __future__ import annotations
 
-import json
 import logging
-import uuid
-import voluptuous as vol
+from datetime import timedelta
+from typing import Any
 
-from .const import DOMAIN
-from homeassistant.components import homeassistant
-from homeassistant.components.sensor import (
-    SensorDeviceClass,
-    SensorEntity,
-    SensorStateClass,
-)
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.const import UnitOfTemperature
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import generate_entity_id
-from homeassistant.helpers.entity_registry import async_get
-from homeassistant.helpers.json import save_json
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
 from homeassistant.util import slugify
-from homeassistant.util import dt
-from homeassistant.util.json import JsonArrayType, load_json_array
-from datetime import datetime, timedelta
 
-from .const import DOMAIN
+from .const import (
+    ATTR_CATEGORY,
+    ATTR_FREQUENCY_MS,
+    ATTR_ICON,
+    ATTR_ID,
+    ATTR_LAST_COMPLETED,
+    ATTR_NAME,
+    DEFAULT_ICON,
+    DOMAIN,
+)
+from .coordinator import ActivityManagerCoordinator
 
 _LOGGER = logging.getLogger(__name__)
-PERSISTENCE = ".activities_list.json"
 
 
-async def async_setup_entry(hass, config_entry, async_add_devices):
-    data = hass.data[DOMAIN] = ActivityManager(hass, config_entry, async_add_devices)
-    await data.async_load_activities()
-    activities = []
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Activity Manager sensors from a config entry."""
+    coordinator: ActivityManagerCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    for item in data.items:
-        activities.append(ActivityEntity(hass, config_entry, item))
+    # Store callback on coordinator so it can add entities for new activities.
+    coordinator.async_add_entities = async_add_entities
 
-    async_add_devices(activities, True)
+    entities = [
+        ActivityEntity(coordinator, item[ATTR_ID])
+        for item in (coordinator.data or [])
+    ]
+    async_add_entities(entities)
 
 
-class ActivityManager:
-    """Class to hold activity data."""
+class ActivityEntity(CoordinatorEntity[ActivityManagerCoordinator], SensorEntity):
+    """Sensor entity representing a single recurring activity.
 
-    def __init__(self, hass: HomeAssistant, entry, async_add_devices) -> None:
-        """Initialize the shopping list."""
+    Reads all state live from coordinator.data so it is never stale.
+    CoordinatorEntity automatically calls async_write_ha_state() whenever
+    the coordinator calls async_set_updated_data().
+    """
 
-        self.hass = hass
-        self.async_add_devices = async_add_devices
-        self.items: JsonArrayType = []
-        self.activities = {}
-        self.entry = entry
+    _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
 
-    async def async_add_activity(
-        self, name, category, frequency, icon=None, last_completed=None, context=None
-    ):
-        if last_completed is None:
-            last_completed = dt.now().isoformat()
-
-        if icon is None:
-            icon = "mdi:checkbox-outline"
-
-        item = {
-            "name": name,
-            "category": category,
-            "id": uuid.uuid4().hex,
-            "last_completed": last_completed,
-            "frequency": frequency,
-            "frequency_ms": self._duration_to_ms(frequency),
-            "icon": icon,
-        }
-
-        self.items.append(item)
-        self.async_add_devices([ActivityEntity(self.hass, self.entry, item)], True)
-        await self.update_entities()
-
-        _LOGGER.debug("Added activity: %s", item)
-        self.hass.bus.async_fire(
-            "activity_manager_updated",
-            {"action": "add", "item": item},
-            context=context,
-        )
-
-        return item
-
-    async def async_remove_activity(self, item_id=None, context=None):
-        item = next((itm for itm in self.items if itm["id"] == item_id), None)
-
-        entity_registry = async_get(self.hass)
-        entity = next(
-            (
-                entry
-                for idx, entry in entity_registry.entities.items()
-                if entry.unique_id == item_id
-            ),
-            None,
-        )
-
-        self.items.remove(item)
-        entity_registry.async_remove(entity.entity_id)
-        await self.update_entities()
-        _LOGGER.debug("Removed activity: %s", item)
-
-        self.hass.bus.async_fire(
-            "activity_manager_updated",
-            {"action": "remove", "item": item},
-            context=context,
-        )
-
-        return item
-
-    async def async_update_activity(
+    def __init__(
         self,
-        item_id,
-        last_completed=None,
-        category=None,
-        frequency=None,
-        context=None,
-        icon=None,
-    ):
-        item = next((itm for itm in self.items if itm["id"] == item_id), None)
-
-        if last_completed:
-            item["last_completed"] = last_completed
-
-        if category:
-            item["category"] = category
-
-        if frequency:
-            item["frequency"] = frequency
-            item["frequency_ms"] = self._duration_to_ms(frequency)
-
-        if icon:
-            item["icon"] = icon
-
-        entity_registry = async_get(self.hass)
-        for entity_id, entity_entry in entity_registry.entities.items():
-            if entity_entry.unique_id == item["id"]:  # entity_entry.update()
-                await self.hass.services.async_call(
-                    "homeassistant",
-                    "update_entity",
-                    {"entity_id": entity_entry.entity_id},
-                )
-        await self.update_entities()
-        _LOGGER.debug("Updated activity: %s", item)
-
-        self.hass.bus.async_fire(
-            "activity_manager_updated",
-            {"action": "updated", "item": item},
-            context=context,
-        )
-
-        return item
-
-    async def update_entities(self):
-        await self.hass.async_add_executor_job(self.save)
-
-    async def async_load_activities(self) -> None:
-        """Load items."""
-
-        def load() -> JsonArrayType:
-            """Load the items synchronously."""
-
-            items = load_json_array(self.hass.config.path(PERSISTENCE))
-            for item in items:
-                if "frequency" not in item:
-                    if "frequency_ms" in item:
-                        _LOGGER.error("No frequency, using frequency_ms: %s", item)
-                        continue
-                    else:
-                        item["frequency_ms"] = self._duration_to_ms(7)
-                        _LOGGER.error("Added missing frequency: %s", item)
-                        continue
-
-                # Set frequency_ms
-                item["frequency_ms"] = self._duration_to_ms(item["frequency"])
-
-                if "icon" not in item:
-                    item["icon"] = "mdi:checkbox-outline"
-
-            return items
-
-        self.items = await self.hass.async_add_executor_job(load)
-
-    def save(self) -> None:
-        """Save the items."""
-        items = self.items
-
-        save_json(self.hass.config.path(PERSISTENCE), items)
-
-    def _duration_to_ms(self, frequency) -> int:
-        # prior versions stored a single int for number of days
-        try:
-            return int(frequency) * 24 * 60 * 60 * 1000
-        except:
-            frequency_ms = 0
-            if "days" in frequency:
-                frequency_ms += frequency["days"] * 24 * 60 * 60 * 1000
-            if "hours" in frequency:
-                frequency_ms += frequency["hours"] * 60 * 60 * 1000
-            if "minutes" in frequency:
-                frequency_ms += frequency["minutes"] * 60 * 1000
-            if "seconds" in frequency:
-                frequency_ms += frequency["seconds"] * 1000
-
-            return frequency_ms
-
-
-class ActivityEntity(SensorEntity):
-    """Representation of a sensor."""
-
-    def __init__(self, hass, config, activity) -> None:
-        """Initialize the sensor."""
-        _attr_has_entity_name = True
-        self._hass = hass
-        self._config = config
-        self._activity = activity
-        self._id = self._activity["id"]
+        coordinator: ActivityManagerCoordinator,
+        activity_id: str,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self._activity_id = activity_id
+        activity = self._activity
+        # Prefix unique_id with entry_id to avoid collisions across lists.
+        self._attr_unique_id = f"{coordinator.entry_id}_{activity_id}"
         self.entity_id = "sensor." + slugify(
-            self._activity["category"] + "_" + self._activity["name"]
+            activity.get(ATTR_CATEGORY, "") + "_" + activity.get(ATTR_NAME, "")
         )
-        self._attributes = {
-            "category": self._activity["category"],
-            "last_completed": self._activity["last_completed"],
-            "frequency_ms": self._activity["frequency_ms"],
-            "friendly_name": self._activity["name"],
-            "id": self._activity["id"],
-            "integration": DOMAIN,
-        }
 
     @property
-    def unique_id(self):
-        """Return a unique ID to use for this sensor."""
-        # return slugify(self._activity["category"] + "_" + self._activity["name"])
-        return self._id
-
-    @property
-    def entity_id(self):
-        return self.entity_id
-
-    def entity_id(self, value):
-        self.entity_id = value
+    def _activity(self) -> dict[str, Any]:
+        """Live lookup into coordinator data — never stale."""
+        return next(
+            (
+                item
+                for item in (self.coordinator.data or [])
+                if item[ATTR_ID] == self._activity_id
+            ),
+            {},
+        )
 
     @property
     def name(self) -> str:
-        """Return the name of the sensor."""
-        return self._activity["name"]
+        """Return the activity name."""
+        return self._activity.get(ATTR_NAME, "")
 
     @property
-    def state(self):
-        """Return the state of the sensor."""
-        return dt.as_local(
-            dt.parse_datetime(self._activity["last_completed"])
-        ) + timedelta(milliseconds=self._activity["frequency_ms"])
+    def state(self) -> str:
+        """Return the due datetime as an ISO 8601 string."""
+        activity = self._activity
+        last_completed_str = activity.get(ATTR_LAST_COMPLETED)
+        frequency_ms = activity.get(ATTR_FREQUENCY_MS, 0)
+
+        if not last_completed_str:
+            return dt_util.now().isoformat()
+
+        last_completed = dt_util.parse_datetime(last_completed_str)
+        if last_completed is None:
+            return dt_util.now().isoformat()
+
+        due = dt_util.as_local(last_completed) + timedelta(milliseconds=frequency_ms)
+        return due.isoformat()
 
     @property
-    def extra_state_attributes(self):
-        """Return the state attributes."""
-        return self._attributes
+    def icon(self) -> str:
+        """Return the activity icon."""
+        return self._activity.get(ATTR_ICON, DEFAULT_ICON)
 
     @property
-    def icon(self):
-        """Return the state of the sensor."""
-        return self._activity["icon"]
-
-    def update(self) -> None:
-        """Fetch new state data for the sensor.
-
-        This is the only method that should fetch new data for Home Assistant.
-        """
-        for item in self._hass.data[DOMAIN].items:
-            if self._id == item["id"]:
-                self._attributes["last_completed"] = item["last_completed"]
-                self._attributes["category"] = item["category"]
-                self._attributes["frequency_ms"] = item["frequency_ms"]
-                self._attributes["icon"] = item["icon"]
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return extra state attributes."""
+        activity = self._activity
+        return {
+            ATTR_CATEGORY: activity.get(ATTR_CATEGORY),
+            ATTR_LAST_COMPLETED: activity.get(ATTR_LAST_COMPLETED),
+            ATTR_FREQUENCY_MS: activity.get(ATTR_FREQUENCY_MS),
+            ATTR_ID: activity.get(ATTR_ID),
+            "integration": DOMAIN,
+            # Expose entry_id and list title so the card can discover available lists.
+            "entry_id": self.coordinator.entry_id,
+            "list_title": self.coordinator.title,
+        }

--- a/custom_components/activity_manager/strings.json
+++ b/custom_components/activity_manager/strings.json
@@ -1,0 +1,27 @@
+{
+  "title": "Activity Manager",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Create Activity List",
+        "description": "Enter a name for this activity list (e.g. Home, Social).",
+        "data": {
+          "name": "List name"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "A list with this name already exists."
+    },
+    "error": {
+      "name_required": "List name cannot be empty."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Activity Manager Options"
+      }
+    }
+  }
+}

--- a/custom_components/activity_manager/strings.json
+++ b/custom_components/activity_manager/strings.json
@@ -20,7 +20,10 @@
   "options": {
     "step": {
       "init": {
-        "title": "Activity Manager Options"
+        "title": "Rename Activity List",
+        "data": {
+          "name": "List name"
+        }
       }
     }
   }

--- a/custom_components/activity_manager/translations/en.json
+++ b/custom_components/activity_manager/translations/en.json
@@ -1,0 +1,27 @@
+{
+  "title": "Activity Manager",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Create Activity List",
+        "description": "Enter a name for this activity list (e.g. Home, Social).",
+        "data": {
+          "name": "List name"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "A list with this name already exists."
+    },
+    "error": {
+      "name_required": "List name cannot be empty."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Activity Manager Options"
+      }
+    }
+  }
+}

--- a/custom_components/activity_manager/translations/en.json
+++ b/custom_components/activity_manager/translations/en.json
@@ -20,7 +20,10 @@
   "options": {
     "step": {
       "init": {
-        "title": "Activity Manager Options"
+        "title": "Rename Activity List",
+        "data": {
+          "name": "List name"
+        }
       }
     }
   }

--- a/custom_components/activity_manager/utils.py
+++ b/custom_components/activity_manager/utils.py
@@ -1,5 +1,34 @@
-from homeassistant.util import dt
+"""Utility functions for Activity Manager."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.util import dt as dt_util
+
+_LOGGER = logging.getLogger(__name__)
 
 
-def dt_as_local(dt_str=None):
-    return dt.as_local(dt.parse_datetime(dt_str)).isoformat()
+def dt_as_local(dt_str: str) -> str:
+    """Parse an ISO datetime string and return it in local time as an ISO string."""
+    parsed = dt_util.parse_datetime(dt_str)
+    if parsed is None:
+        raise ValueError(f"Cannot parse datetime string: {dt_str!r}")
+    return dt_util.as_local(parsed).isoformat()
+
+
+def duration_to_ms(frequency: dict | int) -> int:
+    """Convert a frequency dict or legacy integer (days) to milliseconds."""
+    try:
+        return int(frequency) * 24 * 60 * 60 * 1000
+    except (TypeError, ValueError):
+        pass
+
+    if not isinstance(frequency, dict):
+        raise TypeError(f"Expected dict or int for frequency, got {type(frequency)!r}")
+
+    ms = 0
+    ms += frequency.get("days", 0) * 24 * 60 * 60 * 1000
+    ms += frequency.get("hours", 0) * 60 * 60 * 1000
+    ms += frequency.get("minutes", 0) * 60 * 1000
+    ms += frequency.get("seconds", 0) * 1000
+    return ms

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
+[tool.coverage.run]
+source = ["custom_components/activity_manager"]
+omit = ["tests/*"]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-asyncio
+pytest-homeassistant-custom-component

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,126 @@
+"""Shared test fixtures for Activity Manager."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.activity_manager.const import DOMAIN
+
+
+# Automatically enable custom integration loading for all tests in this suite.
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Enable custom integrations for every test."""
+
+
+@pytest.fixture(scope="session", autouse=True)
+async def prime_aiohttp_server():
+    """Start and immediately close a dummy aiohttp application so the
+    safe-shutdown-loop background thread is running before pytest_homeassistant_custom_component
+    snapshots the thread list at hass fixture setup time.
+
+    Without this, the first test using hass_ws_client creates the thread and it
+    appears as 'lingering' during teardown even though it's a daemon thread from
+    the aiohttp library itself.
+    """
+    import aiohttp
+    app = aiohttp.web.Application()
+    runner = aiohttp.web.AppRunner(app)
+    await runner.setup()
+    await runner.cleanup()
+
+
+
+SAMPLE_ACTIVITIES = [
+    {
+        "id": "aabbcc001122",
+        "name": "Water Plants",
+        "category": "Garden",
+        "frequency": {"days": 7},
+        "frequency_ms": 604800000,
+        "last_completed": "2026-04-01T10:00:00+00:00",
+        "icon": "mdi:flower",
+    },
+    {
+        "id": "ddeeff334455",
+        "name": "Oil Change",
+        "category": "Car",
+        "frequency": {"days": 90},
+        "frequency_ms": 7776000000,
+        "last_completed": "2026-01-01T10:00:00+00:00",
+        "icon": "mdi:car",
+    },
+]
+
+LEGACY_ACTIVITY = {
+    "id": "legacy000001",
+    "name": "Weekly Chores",
+    "category": "Home",
+    # Legacy integer frequency (days)
+    "frequency": 7,
+    "last_completed": "2026-03-01T10:00:00+00:00",
+    "icon": "mdi:broom",
+}
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a mock Activity Manager config entry for 'Home' list."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Home"},
+        title="Home",
+        unique_id="home",
+        version=1,
+        minor_version=3,
+    )
+
+
+@pytest.fixture
+def mock_config_entry_2() -> MockConfigEntry:
+    """Return a second mock Activity Manager config entry for 'Social' list."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Social"},
+        title="Social",
+        unique_id="social",
+        version=1,
+        minor_version=3,
+    )
+
+
+@pytest.fixture
+def mock_empty_persistence():
+    """Patch load_json_array to return an empty list and os.path.exists to return True."""
+    with (
+        patch("custom_components.activity_manager.coordinator.os.path.exists", return_value=True),
+        patch(
+            "custom_components.activity_manager.coordinator.load_json_array",
+            return_value=[],
+        ),
+    ):
+        yield
+
+
+@pytest.fixture
+def mock_persistence():
+    """Patch load_json_array to return sample activities and os.path.exists to return True."""
+    with (
+        patch("custom_components.activity_manager.coordinator.os.path.exists", return_value=True),
+        patch(
+            "custom_components.activity_manager.coordinator.load_json_array",
+            return_value=list(SAMPLE_ACTIVITIES),
+        ),
+    ):
+        yield
+
+
+@pytest.fixture
+def mock_save():
+    """Patch save_json so tests don't write to disk."""
+    with patch(
+        "custom_components.activity_manager.coordinator.save_json"
+    ) as mock:
+        yield mock

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,245 @@
+"""Tests for ActivityManagerCoordinator."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from custom_components.activity_manager.const import (
+    ATTR_CATEGORY,
+    ATTR_FREQUENCY_MS,
+    ATTR_ID,
+    ATTR_LAST_COMPLETED,
+    ATTR_NAME,
+    DOMAIN,
+    EVENT_UPDATED,
+)
+from custom_components.activity_manager.coordinator import ActivityManagerCoordinator
+
+from .conftest import LEGACY_ACTIVITY, SAMPLE_ACTIVITIES
+
+
+@pytest.fixture
+async def coordinator(hass, mock_config_entry, mock_persistence, mock_save):
+    """Return a loaded coordinator with sample data."""
+    mock_config_entry.add_to_hass(hass)
+    coord = ActivityManagerCoordinator(hass, mock_config_entry)
+    await coord.async_load()
+    return coord
+
+
+@pytest.fixture
+async def empty_coordinator(hass, mock_config_entry, mock_empty_persistence, mock_save):
+    """Return a loaded coordinator with no data."""
+    mock_config_entry.add_to_hass(hass)
+    coord = ActivityManagerCoordinator(hass, mock_config_entry)
+    await coord.async_load()
+    return coord
+
+
+@pytest.fixture
+async def two_coordinators(hass, mock_config_entry, mock_config_entry_2, mock_save):
+    """Return two coordinators for multi-instance tests."""
+    mock_config_entry.add_to_hass(hass)
+    mock_config_entry_2.add_to_hass(hass)
+
+    with (
+        patch("custom_components.activity_manager.coordinator.os.path.exists", return_value=True),
+        patch(
+            "custom_components.activity_manager.coordinator.load_json_array",
+            return_value=list(SAMPLE_ACTIVITIES),
+        ),
+    ):
+        coord1 = ActivityManagerCoordinator(hass, mock_config_entry)
+        await coord1.async_load()
+
+    with (
+        patch("custom_components.activity_manager.coordinator.os.path.exists", return_value=True),
+        patch(
+            "custom_components.activity_manager.coordinator.load_json_array",
+            return_value=[],
+        ),
+    ):
+        coord2 = ActivityManagerCoordinator(hass, mock_config_entry_2)
+        await coord2.async_load()
+
+    return coord1, coord2
+
+
+async def test_load_activities(coordinator):
+    """Coordinator loads sample activities from disk."""
+    assert len(coordinator.data) == 2
+    assert coordinator.data[0][ATTR_NAME] == "Water Plants"
+    assert coordinator.data[1][ATTR_NAME] == "Oil Change"
+
+
+async def test_frequency_ms_computed_on_load(coordinator):
+    """frequency_ms is (re)computed from frequency dict on load."""
+    item = coordinator.data[0]
+    # 7 days in ms
+    assert item[ATTR_FREQUENCY_MS] == 7 * 24 * 60 * 60 * 1000
+
+
+async def test_legacy_integer_frequency_migrated(hass, mock_config_entry, mock_save):
+    """Legacy integer frequency is converted to ms correctly."""
+    with (
+        patch("custom_components.activity_manager.coordinator.os.path.exists", return_value=True),
+        patch(
+            "custom_components.activity_manager.coordinator.load_json_array",
+            return_value=[dict(LEGACY_ACTIVITY)],
+        ),
+    ):
+        mock_config_entry.add_to_hass(hass)
+        coord = ActivityManagerCoordinator(hass, mock_config_entry)
+        await coord.async_load()
+
+    assert len(coord.data) == 1
+    assert coord.data[0][ATTR_FREQUENCY_MS] == 7 * 24 * 60 * 60 * 1000
+
+
+async def test_corrupt_activity_skipped(hass, mock_config_entry, mock_save, caplog):
+    """Activity missing frequency key is skipped with a warning."""
+    corrupt = {"id": "baditem", "name": "No Frequency", "category": "Test"}
+    with (
+        patch("custom_components.activity_manager.coordinator.os.path.exists", return_value=True),
+        patch(
+            "custom_components.activity_manager.coordinator.load_json_array",
+            return_value=[corrupt],
+        ),
+    ):
+        mock_config_entry.add_to_hass(hass)
+        coord = ActivityManagerCoordinator(hass, mock_config_entry)
+        await coord.async_load()
+
+    assert len(coord.data) == 0
+    assert "baditem" in caplog.text
+
+
+async def test_add_activity(empty_coordinator, hass):
+    """Adding an activity updates coordinator data and fires event."""
+    events = []
+    hass.bus.async_listen(EVENT_UPDATED, lambda e: events.append(e))
+
+    item = await empty_coordinator.async_add_activity(
+        name="Vacuum",
+        category="Home",
+        frequency={"days": 7},
+        icon="mdi:vacuum",
+    )
+
+    assert len(empty_coordinator.data) == 1
+    assert empty_coordinator.data[0][ATTR_NAME] == "Vacuum"
+    assert ATTR_ID in item
+    await hass.async_block_till_done()
+    assert len(events) == 1
+    assert events[0].data["action"] == "add"
+
+
+async def test_add_activity_saves_to_disk(empty_coordinator, mock_save):
+    """Adding an activity triggers a save."""
+    await empty_coordinator.async_add_activity(
+        name="Test", category="Test", frequency={"days": 1}
+    )
+    mock_save.assert_called_once()
+
+
+async def test_remove_activity(coordinator, hass):
+    """Removing an activity updates coordinator data and fires event."""
+    events = []
+    hass.bus.async_listen(EVENT_UPDATED, lambda e: events.append(e))
+
+    item_id = SAMPLE_ACTIVITIES[0]["id"]
+    removed = await coordinator.async_remove_activity(item_id)
+
+    assert removed[ATTR_ID] == item_id
+    assert len(coordinator.data) == 1
+    assert coordinator.data[0][ATTR_NAME] == "Oil Change"
+    await hass.async_block_till_done()
+    assert events[0].data["action"] == "remove"
+
+
+async def test_remove_unknown_activity_returns_none(coordinator):
+    """Removing a non-existent id returns None without error."""
+    result = await coordinator.async_remove_activity("nonexistent-id")
+    assert result is None
+    assert len(coordinator.data) == 2  # unchanged
+
+
+async def test_update_activity(coordinator, hass):
+    """Updating an activity mutates the correct item and fires event."""
+    events = []
+    hass.bus.async_listen(EVENT_UPDATED, lambda e: events.append(e))
+
+    item_id = SAMPLE_ACTIVITIES[0]["id"]
+    new_ts = "2026-04-08T12:00:00+00:00"
+    updated = await coordinator.async_update_activity(item_id, last_completed=new_ts)
+
+    assert updated[ATTR_LAST_COMPLETED] == new_ts
+    assert coordinator.data[0][ATTR_LAST_COMPLETED] == new_ts
+    # Other item unchanged
+    assert coordinator.data[1][ATTR_LAST_COMPLETED] == SAMPLE_ACTIVITIES[1]["last_completed"]
+    await hass.async_block_till_done()
+    assert events[0].data["action"] == "updated"
+
+
+async def test_update_frequency_recomputes_ms(coordinator):
+    """Updating frequency also recomputes frequency_ms."""
+    item_id = SAMPLE_ACTIVITIES[0]["id"]
+    await coordinator.async_update_activity(item_id, frequency={"days": 14})
+
+    assert coordinator.data[0][ATTR_FREQUENCY_MS] == 14 * 24 * 60 * 60 * 1000
+
+
+async def test_update_unknown_activity_returns_none(coordinator):
+    """Updating a non-existent id returns None without error."""
+    result = await coordinator.async_update_activity("nonexistent-id", category="X")
+    assert result is None
+    assert len(coordinator.data) == 2  # unchanged
+
+
+async def test_data_immutability_between_mutations(coordinator):
+    """Each mutation creates a new list; the old snapshot is not mutated."""
+    snapshot_before = coordinator.data
+    item_id = SAMPLE_ACTIVITIES[0]["id"]
+    await coordinator.async_update_activity(item_id, last_completed="2026-04-08T00:00:00+00:00")
+
+    # coordinator.data is a new list object after the update
+    assert coordinator.data is not snapshot_before
+
+
+async def test_coordinator_exposes_entry_id_and_title(mock_config_entry, mock_persistence, mock_save, hass):
+    """Coordinator exposes entry_id and title for card discovery."""
+    mock_config_entry.add_to_hass(hass)
+    coord = ActivityManagerCoordinator(hass, mock_config_entry)
+    await coord.async_load()
+
+    assert coord.entry_id == mock_config_entry.entry_id
+    assert coord.title == "Home"
+
+
+async def test_two_coordinators_are_isolated(two_coordinators):
+    """Two coordinators operate on independent data."""
+    coord1, coord2 = two_coordinators
+
+    # coord1 has 2 activities from SAMPLE_ACTIVITIES
+    assert len(coord1.data) == 2
+    # coord2 starts empty
+    assert len(coord2.data) == 0
+
+    # Mutating coord2 doesn't affect coord1
+    await coord2.async_add_activity(name="Social Meet", category="Friends", frequency={"days": 30})
+    assert len(coord2.data) == 1
+    assert len(coord1.data) == 2
+
+
+async def test_event_includes_entry_id(empty_coordinator, hass, mock_config_entry):
+    """EVENT_UPDATED includes entry_id so subscribers can identify the source list."""
+    events = []
+    hass.bus.async_listen(EVENT_UPDATED, lambda e: events.append(e))
+
+    await empty_coordinator.async_add_activity(
+        name="Test", category="Test", frequency={"days": 1}
+    )
+    await hass.async_block_till_done()
+
+    assert events[0].data["entry_id"] == mock_config_entry.entry_id

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,92 @@
+"""Tests for ActivityEntity sensor."""
+from __future__ import annotations
+
+import pytest
+
+from custom_components.activity_manager.const import (
+    ATTR_LAST_COMPLETED,
+    DOMAIN,
+)
+from custom_components.activity_manager.coordinator import ActivityManagerCoordinator
+from custom_components.activity_manager.sensor import ActivityEntity
+
+from .conftest import SAMPLE_ACTIVITIES
+
+
+@pytest.fixture
+async def coordinator(hass, mock_config_entry, mock_persistence, mock_save):
+    """Return a loaded coordinator."""
+    mock_config_entry.add_to_hass(hass)
+    coord = ActivityManagerCoordinator(hass, mock_config_entry)
+    await coord.async_load()
+    return coord
+
+
+async def test_state_is_string(coordinator):
+    """Entity state must be a string (ISO datetime), not a datetime object."""
+    entity = ActivityEntity(coordinator, SAMPLE_ACTIVITIES[0]["id"])
+    state = entity.state
+    assert isinstance(state, str)
+    # Basic ISO 8601 sanity check
+    assert "T" in state
+
+
+async def test_entity_id_no_recursion(coordinator):
+    """Accessing entity_id must not raise RecursionError."""
+    entity = ActivityEntity(coordinator, SAMPLE_ACTIVITIES[0]["id"])
+    try:
+        eid = entity.entity_id
+    except RecursionError:
+        pytest.fail("entity_id caused infinite recursion")
+    assert isinstance(eid, str)
+    assert eid.startswith("sensor.")
+
+
+async def test_has_entity_name_is_class_attribute(coordinator):
+    """_attr_has_entity_name must be True on the class or its instances."""
+    entity = ActivityEntity(coordinator, SAMPLE_ACTIVITIES[0]["id"])
+    # Check via instance (handles both direct class attr and property on base class)
+    assert entity._attr_has_entity_name is True
+
+
+async def test_entity_reflects_coordinator_update(coordinator, hass):
+    """After coordinator update, entity state reflects the new last_completed."""
+    entity = ActivityEntity(coordinator, SAMPLE_ACTIVITIES[0]["id"])
+    # Simulate HA adding the entity
+    entity.hass = hass
+
+    original_state = entity.state
+
+    new_ts = "2026-04-08T12:00:00+00:00"
+    await coordinator.async_update_activity(SAMPLE_ACTIVITIES[0]["id"], last_completed=new_ts)
+
+    # The _activity property does a live lookup — state must reflect new data
+    assert entity.state != original_state
+    assert entity.extra_state_attributes[ATTR_LAST_COMPLETED] == new_ts
+
+
+async def test_extra_state_attributes_keys(coordinator):
+    """Extra state attributes contain the expected keys including entry_id and list_title."""
+    entity = ActivityEntity(coordinator, SAMPLE_ACTIVITIES[0]["id"])
+    attrs = entity.extra_state_attributes
+    for key in ("category", "last_completed", "frequency_ms", "id", "integration", "entry_id", "list_title"):
+        assert key in attrs, f"Missing key: {key}"
+
+
+async def test_unique_id_prefixed_with_entry_id(coordinator):
+    """unique_id must be prefixed with entry_id to avoid collisions across lists."""
+    entity = ActivityEntity(coordinator, SAMPLE_ACTIVITIES[0]["id"])
+    assert entity._attr_unique_id.startswith(coordinator.entry_id + "_")
+    assert entity._attr_unique_id.endswith(SAMPLE_ACTIVITIES[0]["id"])
+
+
+async def test_name_returns_activity_name(coordinator):
+    """Entity name matches the activity name."""
+    entity = ActivityEntity(coordinator, SAMPLE_ACTIVITIES[0]["id"])
+    assert entity.name == "Water Plants"
+
+
+async def test_icon_returns_activity_icon(coordinator):
+    """Entity icon matches the activity icon."""
+    entity = ActivityEntity(coordinator, SAMPLE_ACTIVITIES[0]["id"])
+    assert entity.icon == "mdi:flower"

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,0 +1,260 @@
+"""Tests for Activity Manager websocket API."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.activity_manager.const import (
+    DOMAIN,
+    EVENT_UPDATED,
+    WS_ADD,
+    WS_ITEMS,
+    WS_REMOVE,
+    WS_UPDATE,
+)
+
+from .conftest import SAMPLE_ACTIVITIES
+
+
+@pytest.fixture
+async def setup_integration(hass, mock_config_entry, mock_persistence, mock_save):
+    """Set up the integration and return (hass, entry_id)."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    return hass, mock_config_entry.entry_id
+
+
+@pytest.fixture
+async def setup_two_integrations(hass, mock_save):
+    """Set up two list instances and return (hass, entry_id_1, entry_id_2)."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.activity_manager.const import DOMAIN
+
+    entry1 = MockConfigEntry(
+        domain=DOMAIN, data={"name": "Home"}, title="Home", unique_id="home",
+        version=1, minor_version=3,
+    )
+    entry2 = MockConfigEntry(
+        domain=DOMAIN, data={"name": "Social"}, title="Social", unique_id="social",
+        version=1, minor_version=3,
+    )
+
+    with (
+        patch("custom_components.activity_manager.coordinator.os.path.exists", return_value=True),
+        patch(
+            "custom_components.activity_manager.coordinator.load_json_array",
+            return_value=list(SAMPLE_ACTIVITIES),
+        ),
+    ):
+        entry1.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry1.entry_id)
+
+    with (
+        patch("custom_components.activity_manager.coordinator.os.path.exists", return_value=True),
+        patch(
+            "custom_components.activity_manager.coordinator.load_json_array",
+            return_value=[],
+        ),
+    ):
+        entry2.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry2.entry_id)
+
+    await hass.async_block_till_done()
+    return hass, entry1.entry_id, entry2.entry_id
+
+
+def _coordinator(hass, entry_id):
+    return hass.data[DOMAIN][entry_id]
+
+
+async def test_ws_items_returns_list(hass, setup_integration, hass_ws_client):
+    """activity_manager/items returns the full list of activities."""
+    hass, entry_id = setup_integration
+    client = await hass_ws_client(hass)
+    await client.send_json({"id": 1, "type": WS_ITEMS, "entry_id": entry_id})
+    msg = await client.receive_json()
+
+    assert msg["success"] is True
+    assert isinstance(msg["result"], list)
+    assert len(msg["result"]) == 2
+
+
+async def test_ws_items_no_entry_id_returns_all(hass, setup_two_integrations, hass_ws_client):
+    """activity_manager/items without entry_id returns all lists merged."""
+    hass, entry_id_1, entry_id_2 = setup_two_integrations
+    # Add one activity to the second list
+    coord2 = _coordinator(hass, entry_id_2)
+    await coord2.async_add_activity(name="Social", category="Friends", frequency={"days": 7})
+
+    client = await hass_ws_client(hass)
+    await client.send_json({"id": 1, "type": WS_ITEMS})
+    msg = await client.receive_json()
+
+    assert msg["success"] is True
+    # 2 from list 1 + 1 from list 2
+    assert len(msg["result"]) == 3
+    # Each item is tagged with its list's entry_id
+    entry_ids_in_result = {item["entry_id"] for item in msg["result"]}
+    assert entry_id_1 in entry_ids_in_result
+    assert entry_id_2 in entry_ids_in_result
+
+
+async def test_ws_items_category_filter(hass, setup_integration, hass_ws_client):
+    """activity_manager/items filters by category when provided."""
+    hass, entry_id = setup_integration
+    client = await hass_ws_client(hass)
+    await client.send_json({"id": 1, "type": WS_ITEMS, "entry_id": entry_id, "category": "Garden"})
+    msg = await client.receive_json()
+
+    assert msg["success"] is True
+    assert len(msg["result"]) == 1
+    assert msg["result"][0]["name"] == "Water Plants"
+
+
+async def test_ws_items_unknown_entry_id_returns_error(hass, setup_integration, hass_ws_client):
+    """activity_manager/items with unknown entry_id returns an error."""
+    hass, _ = setup_integration
+    client = await hass_ws_client(hass)
+    await client.send_json({"id": 1, "type": WS_ITEMS, "entry_id": "nonexistent"})
+    msg = await client.receive_json()
+
+    assert msg["success"] is False
+
+
+async def test_ws_add_creates_activity(hass, setup_integration, hass_ws_client):
+    """activity_manager/add creates a new activity and returns it."""
+    hass, entry_id = setup_integration
+    client = await hass_ws_client(hass)
+    await client.send_json({
+        "id": 1,
+        "type": WS_ADD,
+        "entry_id": entry_id,
+        "name": "Vacuum",
+        "category": "Home",
+        "frequency": {"days": 7},
+        "icon": "mdi:vacuum",
+    })
+    msg = await client.receive_json()
+
+    assert msg["success"] is True
+    assert msg["result"]["name"] == "Vacuum"
+    assert "id" in msg["result"]
+
+    coordinator = _coordinator(hass, entry_id)
+    names = [i["name"] for i in coordinator.data]
+    assert "Vacuum" in names
+
+
+async def test_ws_add_fires_event(hass, setup_integration, hass_ws_client):
+    """activity_manager/add fires activity_manager_updated event."""
+    hass, entry_id = setup_integration
+    events = []
+    hass.bus.async_listen(EVENT_UPDATED, lambda e: events.append(e))
+
+    client = await hass_ws_client(hass)
+    await client.send_json({
+        "id": 1,
+        "type": WS_ADD,
+        "entry_id": entry_id,
+        "name": "Test",
+        "category": "Test",
+        "frequency": {"days": 1},
+    })
+    await client.receive_json()
+    await hass.async_block_till_done()
+
+    assert len(events) == 1
+    assert events[0].data["action"] == "add"
+    assert events[0].data["entry_id"] == entry_id
+
+
+async def test_ws_add_to_different_lists_are_isolated(hass, setup_two_integrations, hass_ws_client):
+    """Adding to list 1 does not affect list 2."""
+    hass, entry_id_1, entry_id_2 = setup_two_integrations
+    client = await hass_ws_client(hass)
+    await client.send_json({
+        "id": 1,
+        "type": WS_ADD,
+        "entry_id": entry_id_1,
+        "name": "Home Task",
+        "category": "Home",
+        "frequency": {"days": 7},
+    })
+    await client.receive_json()
+
+    assert len(_coordinator(hass, entry_id_1).data) == 3
+    assert len(_coordinator(hass, entry_id_2).data) == 0
+
+
+async def test_ws_update_sets_last_completed(hass, setup_integration, hass_ws_client):
+    """activity_manager/update updates last_completed on an activity."""
+    hass, entry_id = setup_integration
+    item_id = SAMPLE_ACTIVITIES[0]["id"]
+    new_ts = "2026-04-08T12:00:00+00:00"
+
+    client = await hass_ws_client(hass)
+    await client.send_json({
+        "id": 1,
+        "type": WS_UPDATE,
+        "entry_id": entry_id,
+        "item_id": item_id,
+        "last_completed": new_ts,
+    })
+    msg = await client.receive_json()
+
+    assert msg["success"] is True
+    coordinator = _coordinator(hass, entry_id)
+    updated = next(i for i in coordinator.data if i["id"] == item_id)
+    assert updated["last_completed"] is not None
+
+
+async def test_ws_update_unknown_id_returns_error(hass, setup_integration, hass_ws_client):
+    """activity_manager/update with unknown id returns an error message."""
+    hass, entry_id = setup_integration
+    client = await hass_ws_client(hass)
+    await client.send_json({
+        "id": 1,
+        "type": WS_UPDATE,
+        "entry_id": entry_id,
+        "item_id": "nonexistent-id",
+    })
+    msg = await client.receive_json()
+
+    assert msg["success"] is False
+
+
+async def test_ws_remove_deletes_activity(hass, setup_integration, hass_ws_client):
+    """activity_manager/remove removes the activity from coordinator data."""
+    hass, entry_id = setup_integration
+    item_id = SAMPLE_ACTIVITIES[0]["id"]
+
+    client = await hass_ws_client(hass)
+    await client.send_json({
+        "id": 1,
+        "type": WS_REMOVE,
+        "entry_id": entry_id,
+        "item_id": item_id,
+    })
+    msg = await client.receive_json()
+
+    assert msg["success"] is True
+    coordinator = _coordinator(hass, entry_id)
+    assert all(i["id"] != item_id for i in coordinator.data)
+
+
+async def test_ws_remove_unknown_id_returns_error(hass, setup_integration, hass_ws_client):
+    """activity_manager/remove with unknown id returns an error message."""
+    hass, entry_id = setup_integration
+    client = await hass_ws_client(hass)
+    await client.send_json({
+        "id": 1,
+        "type": WS_REMOVE,
+        "entry_id": entry_id,
+        "item_id": "nonexistent-id",
+    })
+    msg = await client.receive_json()
+
+    assert msg["success"] is False


### PR DESCRIPTION
## Summary

- **Multi-instance**: each config entry is an independent activity list; all WS commands and services route by `entry_id`
- **Graceful upgrade**: legacy `.activities_list.json` auto-migrates to per-entry files on first load; `.bak` backup created before migration
- **List rename**: options flow now lets users rename a list via Settings → Configure
- **Service improvements**: `update_activity` and `remove_activity` no longer require `entry_id` (derived from entity); `add_activity` uses human-readable `list` name instead of raw `entry_id`
- **Race condition fix**: WS handlers and services registered once using `_registered` flag, safe for concurrent config entry loading
- **Notification blueprint**: ready-made automation blueprint for overdue notifications with category filter, time, and notify target inputs
- **README rewrite**: full documentation for new and legacy users, entity attributes table, service parameter tables

## Test plan

- [ ] Run `pytest tests/ -q` — 34 tests pass
- [ ] Fresh install: add integration, add activities, verify per-entry file created
- [ ] Legacy upgrade: existing `.activities_list.json` migrates, `.bak` created
- [ ] Multiple lists: add integration twice, verify isolation
- [ ] Rename list via Settings → Configure
- [ ] `add_activity` service with `list: "Home"` works
- [ ] `update_activity` and `remove_activity` work without `entry_id`
- [ ] Import blueprint, create automation, verify notification fires

🤖 Generated with [Claude Code](https://claude.ai/claude-code)